### PR TITLE
Fix function keys not working and retry more often when getting values.

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -207,26 +207,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, MediaKeyTapDelegate {
 		guard let currentDisplay = Utils.getCurrentDisplay(from: displays) else { return }
 		let allDisplays = prefs.bool(forKey: Utils.PrefKeys.allScreens.rawValue) ? displays : [currentDisplay]
 		for display in allDisplays {
-			var rel = 0
-			if prefs.bool(forKey: "\(display.identifier)-state") {
+			if (prefs.object(forKey: "\(display.identifier)-state") as? Bool) ?? true {
 				switch mediaKey {
 				case .brightnessUp:
-					rel = +self.step
-					let value = display.calcNewValue(for: BRIGHTNESS, withRel: rel)
+					let value = display.calcNewValue(for: BRIGHTNESS, withRel: +step)
 					display.setBrightness(to: value)
 				case .brightnessDown:
-					rel = -self.step
-					let value = currentDisplay.calcNewValue(for: BRIGHTNESS, withRel: rel)
+					let value = currentDisplay.calcNewValue(for: BRIGHTNESS, withRel: -step)
 					display.setBrightness(to: value)
 				case .mute:
 					display.mute()
 				case .volumeUp:
-					rel = +self.step
-					let value = display.calcNewValue(for: AUDIO_SPEAKER_VOLUME, withRel: rel)
+					let value = display.calcNewValue(for: AUDIO_SPEAKER_VOLUME, withRel: +step)
 					display.setVolume(to: value)
 				case .volumeDown:
-					rel = -self.step
-					let value = display.calcNewValue(for: AUDIO_SPEAKER_VOLUME, withRel: rel)
+					let value = display.calcNewValue(for: AUDIO_SPEAKER_VOLUME, withRel: -step)
 					display.setVolume(to: value)
 				default:
 					return

--- a/MonitorControl/Objects/ButtonCellView.swift
+++ b/MonitorControl/Objects/ButtonCellView.swift
@@ -28,7 +28,10 @@ class ButtonCellView: NSTableCellView {
 			default:
 				break
 			}
+
+			#if DEBUG
 			print("Toggle enabled display state -> \(sender.state == .on ? "on" : "off")")
+			#endif
 		}
 	}
 }

--- a/MonitorControl/Prefs/DisplayPrefsViewController.swift
+++ b/MonitorControl/Prefs/DisplayPrefsViewController.swift
@@ -65,10 +65,7 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
 
 				let name = Utils.getDisplayName(forEdid: edid)
 				let serial = Utils.getDisplaySerial(forEdid: edid)
-				var isEnabled = true
-				if let enabled = prefs.object(forKey: "\(id)-state") as? Bool {
-					isEnabled = enabled
-				}
+				let isEnabled = (prefs.object(forKey: "\(id)-state") as? Bool) ?? true
 
 				let display = Display(id, name: name, serial: serial, isEnabled: isEnabled)
 				displays.append(display)

--- a/MonitorControl/Prefs/DisplayPrefsViewController.swift
+++ b/MonitorControl/Prefs/DisplayPrefsViewController.swift
@@ -42,7 +42,10 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
 			prefs.set(false, forKey: Utils.PrefKeys.allScreens.rawValue)
 		default: break
 		}
+
+		#if DEBUG
 		print("Toggle allScreens state -> \(sender.state == .on ? "on" : "off")")
+		#endif
 	}
 
 	// MARK: - Table datasource

--- a/MonitorControl/Prefs/KeysPrefsViewController.swift
+++ b/MonitorControl/Prefs/KeysPrefsViewController.swift
@@ -26,7 +26,11 @@ class KeysPrefsViewController: NSViewController, MASPreferencesViewController {
 
 	@IBAction func listenForChanged(_ sender: NSPopUpButton) {
 		prefs.set(sender.selectedTag(), forKey: Utils.PrefKeys.listenFor.rawValue)
+
+		#if DEBUG
 		print("Toggle keys listened for state state -> \(sender.selectedItem?.title ?? "")")
+		#endif
+
 		NotificationCenter.default.post(name: Notification.Name.init(Utils.PrefKeys.listenFor.rawValue), object: nil)
 	}
 

--- a/MonitorControl/Prefs/MainPrefsViewController.swift
+++ b/MonitorControl/Prefs/MainPrefsViewController.swift
@@ -40,7 +40,10 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
 			SMLoginItemSetEnabled(identifier, false)
 		default: break
 		}
+
+		#if DEBUG
 		print("Toggle start at login state -> \(sender.state == .on ? "on" : "off")")
+		#endif
 	}
 
 	@IBAction func showContrastSliderClicked(_ sender: NSButton) {
@@ -51,7 +54,11 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
 			prefs.set(false, forKey: Utils.PrefKeys.showContrast.rawValue)
 		default: break
 		}
+
+		#if DEBUG
 		print("Toggle show contrast slider state -> \(sender.state == .on ? "on" : "off")")
+		#endif
+
 		NotificationCenter.default.post(name: Notification.Name.init(Utils.PrefKeys.showContrast.rawValue), object: nil)
 	}
 
@@ -63,6 +70,9 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
 			prefs.set(false, forKey: Utils.PrefKeys.lowerContrast.rawValue)
 		default: break
 		}
+
+		#if DEBUG
 		print("Toggle lower contrast after brightness state -> \(sender.state == .on ? "on" : "off")")
+		#endif
 	}
 }

--- a/Podfile
+++ b/Podfile
@@ -7,5 +7,4 @@ target 'MonitorControl' do
 
 	pod 'MediaKeyTap', :git => 'https://github.com/the0neyouseek/MediaKeyTap.git'
 	pod 'MASPreferences'
-
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,13 +12,13 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   MediaKeyTap:
-    :commit: f369a24f6c9931f2a1485a6cd1cef94a432bb36e
+    :commit: 61a64c17d598de7126f24befde6bdbd5dc7fa121
     :git: https://github.com/the0neyouseek/MediaKeyTap.git
 
 SPEC CHECKSUMS:
   MASPreferences: c08b8622dd17b47da87669e741efd7c92e970e8c
   MediaKeyTap: b652877e9ae2d52ca4f5310fa5152945ad3f0798
 
-PODFILE CHECKSUM: 3404918793c88a6c1f56a30e54cf0d9afb0cfffb
+PODFILE CHECKSUM: efa14c79ecdfeaf061bbc8ed950ee540d77f987a
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.4.0


### PR DESCRIPTION
This fixes function keys not working because displays aren't enabled by default, but only after unchecking and re-checking them in preferences.

Also I added a loop which tries more often to get the values from the display, since for me the default value of 10 tries in `ddcctl` does not work reliably. For me, the average is at about 200 tries, and can be up to 600 tries. And since this is only done once at launch, there shouldn't be any overhead afterwards.

Fixes https://github.com/the0neyouseek/MonitorControl/issues/13.