### PR TITLE
Addition of a "friendly" display name for Monitors

### DIFF
--- a/MonitorControl.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MonitorControl.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -125,8 +125,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     if let edid = ddc?.edid() {
       let name = Utils.getDisplayName(forEdid: edid)
+      let friendlyName = Utils.getFriendlyDisplayName(forDisplayId: id)
 
-      let display = Display(id, name: name)
+      let display = Display(id, name: name, friendlyName: friendlyName)
 
       let monitorSubMenu: NSMenu = asSubMenu ? NSMenu() : self.statusMenu
 
@@ -153,7 +154,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       self.displays.append(display)
 
       let monitorMenuItem = NSMenuItem()
-      monitorMenuItem.title = "\(name)"
+      monitorMenuItem.title = "\(display.friendlyName)"
       if asSubMenu {
         monitorMenuItem.submenu = monitorSubMenu
       }

--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -125,9 +125,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     if let edid = ddc?.edid() {
       let name = Utils.getDisplayName(forEdid: edid)
-      let friendlyName = Utils.getFriendlyDisplayName(forDisplayId: id)
 
-      let display = Display(id, name: name, friendlyName: friendlyName)
+      let display = Display(id, name: name)
 
       let monitorSubMenu: NSMenu = asSubMenu ? NSMenu() : self.statusMenu
 
@@ -154,7 +153,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       self.displays.append(display)
 
       let monitorMenuItem = NSMenuItem()
-      monitorMenuItem.title = "\(display.friendlyName)"
+      monitorMenuItem.title = "\(display.getFriendlyName())"
       if asSubMenu {
         monitorMenuItem.submenu = monitorSubMenu
       }

--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -177,6 +177,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // subscribe KeyTap event listener
     NotificationCenter.default.addObserver(self, selector: #selector(handleListenForChanged), name: NSNotification.Name(Utils.PrefKeys.listenFor.rawValue), object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handleShowContrastChanged), name: NSNotification.Name(Utils.PrefKeys.showContrast.rawValue), object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(handleFriendlyNameChanged), name: NSNotification.Name(Utils.PrefKeys.friendlyName.rawValue), object: nil)
 
     // subscribe Audio output detector (AMCoreAudio)
     AMCoreAudio.NotificationCenter.defaultCenter.subscribe(self, eventType: AudioHardwareEvent.self, dispatchQueue: DispatchQueue.main)
@@ -223,6 +224,10 @@ extension AppDelegate: MediaKeyTapDelegate {
   }
 
   @objc func handleShowContrastChanged() {
+    self.updateDisplays()
+  }
+
+  @objc func handleFriendlyNameChanged() {
     self.updateDisplays()
   }
 

--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -4,6 +4,7 @@ import DDC
 class Display {
   let identifier: CGDirectDisplayID
   let name: String
+  let friendlyName: String
   var isEnabled: Bool
   var isMuted: Bool = false
   var brightnessSliderHandler: SliderHandler?
@@ -13,9 +14,10 @@ class Display {
 
   private let prefs = UserDefaults.standard
 
-  init(_ identifier: CGDirectDisplayID, name: String, isEnabled: Bool = true) {
+  init(_ identifier: CGDirectDisplayID, name: String, friendlyName: String?, isEnabled: Bool = true) {
     self.identifier = identifier
     self.name = name
+    self.friendlyName = friendlyName ?? name
     self.isEnabled = isEnabled
     self.ddc = DDC(for: identifier)
   }

--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -4,7 +4,6 @@ import DDC
 class Display {
   let identifier: CGDirectDisplayID
   let name: String
-  let friendlyName: String
   var isEnabled: Bool
   var isMuted: Bool = false
   var brightnessSliderHandler: SliderHandler?
@@ -14,10 +13,9 @@ class Display {
 
   private let prefs = UserDefaults.standard
 
-  init(_ identifier: CGDirectDisplayID, name: String, friendlyName: String?, isEnabled: Bool = true) {
+  init(_ identifier: CGDirectDisplayID, name: String, isEnabled: Bool = true) {
     self.identifier = identifier
     self.name = name
-    self.friendlyName = friendlyName ?? name
     self.isEnabled = isEnabled
     self.ddc = DDC(for: identifier)
   }
@@ -133,6 +131,14 @@ class Display {
     let max = self.prefs.integer(forKey: "max-\(command.rawValue)-\(self.identifier)")
 
     return max == 0 ? 100 : max
+  }
+
+  func setFriendlyName(_ value: String) {
+    self.prefs.set(value, forKey: "friendlyName-\(self.identifier)")
+  }
+
+  func getFriendlyName() -> String {
+    return self.prefs.string(forKey: "friendlyName-\(self.identifier)") ?? self.name
   }
 
   private func showOsd(command: DDC.Command, value: Int) {

--- a/MonitorControl/Support/Utils.swift
+++ b/MonitorControl/Support/Utils.swift
@@ -104,17 +104,6 @@ class Utils: NSObject {
     return edid.displayName() ?? NSLocalizedString("Unknown", comment: "")
   }
 
-  /// Get a friendly name of a display
-  ///
-  /// - Parameter displayId: the Id of a display
-  /// - Returns: a string representing a user specified name or nil
-  static func getFriendlyDisplayName(forDisplayId displayId: UInt32) -> String? {
-    if displayId == 188_974_528 {
-      return "Right Monitor"
-    }
-    return nil
-  }
-
   /// Get the main display from a list of display
   ///
   /// - Parameter displays: List of Display

--- a/MonitorControl/Support/Utils.swift
+++ b/MonitorControl/Support/Utils.swift
@@ -137,6 +137,9 @@ class Utils: NSObject {
 
     /// Change Brightness/Volume for all screens
     case allScreens
+
+    /// Friendly name changed
+    case friendlyName
   }
 
   /// Keys for the value of listenFor option

--- a/MonitorControl/Support/Utils.swift
+++ b/MonitorControl/Support/Utils.swift
@@ -104,6 +104,17 @@ class Utils: NSObject {
     return edid.displayName() ?? NSLocalizedString("Unknown", comment: "")
   }
 
+  /// Get a friendly name of a display
+  ///
+  /// - Parameter displayId: the Id of a display
+  /// - Returns: a string representing a user specified name or nil
+  static func getFriendlyDisplayName(forDisplayId displayId: UInt32) -> String? {
+    if displayId == 188_974_528 {
+      return "Right Monitor"
+    }
+    return nil
+  }
+
   /// Get the main display from a list of display
   ///
   /// - Parameter displays: List of Display

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -180,7 +180,7 @@
                                                     </textFieldCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
-                                                        <tableCellView id="aGt-d9-Qcx">
+                                                        <tableCellView id="aGt-d9-Qcx" customClass="FriendlyNameCellView" customModule="MonitorControl" customModuleProvider="target">
                                                             <rect key="frame" x="196" y="1" width="140" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
@@ -191,6 +191,9 @@
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                        <connections>
+                                                                            <action selector="valueChanged:" target="aGt-d9-Qcx" id="Rkl-de-KE5"/>
+                                                                        </connections>
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -173,7 +173,7 @@
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
-                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="afl-95-ZJl">
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="Text Cell" id="afl-95-ZJl">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -187,7 +187,7 @@
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CB1-x8-d9G">
                                                                     <rect key="frame" x="0.0" y="0.0" width="140" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="DGv-iu-Jg1">
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Table View Cell" id="DGv-iu-Jg1">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -79,7 +79,7 @@
             <objects>
                 <viewController storyboardIdentifier="DisplayPrefsVC" id="NAx-6T-ZPc" customClass="DisplayPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="EBf-qN-KaN">
-                        <rect key="frame" x="0.0" y="0.0" width="486" height="223"/>
+                        <rect key="frame" x="0.0" y="0.0" width="677" height="223"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uXD-ZY-N3H">
@@ -91,13 +91,13 @@
                                 </textFieldCell>
                             </textField>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B5k-we-kuP">
-                                <rect key="frame" x="20" y="20" width="446" height="100"/>
+                                <rect key="frame" x="20" y="20" width="637" height="100"/>
                                 <clipView key="contentView" drawsBackground="NO" id="4ot-Jo-X5O">
-                                    <rect key="frame" x="1" y="0.0" width="444" height="99"/>
+                                    <rect key="frame" x="1" y="0.0" width="635" height="99"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" headerView="ckY-Px-mJn" viewBased="YES" id="dyo-uY-pMe">
-                                            <rect key="frame" x="0.0" y="0.0" width="444" height="76"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="635" height="76"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -167,6 +167,39 @@
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
+                                                <tableColumn width="140" minWidth="40" maxWidth="1000" id="uoI-1J-RdD">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Friendly Name">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="afl-95-ZJl">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="aGt-d9-Qcx">
+                                                            <rect key="frame" x="196" y="1" width="140" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CB1-x8-d9G">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="140" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="DGv-iu-Jg1">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <connections>
+                                                                <outlet property="textField" destination="CB1-x8-d9G" id="iTj-Jy-ijH"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
                                                 <tableColumn width="80" minWidth="10" maxWidth="3.4028234663852886e+38" id="dgp-q7-cBK">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="ID">
                                                         <font key="font" metaFont="smallSystem"/>
@@ -181,7 +214,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="vw4-Us-VHk">
-                                                            <rect key="frame" x="196" y="1" width="80" height="17"/>
+                                                            <rect key="frame" x="339" y="1" width="80" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z5b-Gr-EmC">
@@ -214,7 +247,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="eVa-Md-Avh">
-                                                            <rect key="frame" x="279" y="1" width="80" height="17"/>
+                                                            <rect key="frame" x="422" y="1" width="80" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NK1-rO-I0Z">
@@ -233,7 +266,7 @@
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
-                                                <tableColumn width="80" minWidth="10" maxWidth="3.4028234663852886e+38" id="Nvp-hI-w4x">
+                                                <tableColumn width="128" minWidth="10" maxWidth="3.4028234663852886e+38" id="Nvp-hI-w4x">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Model">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -247,11 +280,11 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="C4F-JT-GfP">
-                                                            <rect key="frame" x="362" y="1" width="80" height="17"/>
+                                                            <rect key="frame" x="505" y="1" width="128" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Vl-7d-eft">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="80" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="4or-hS-WeW">
                                                                         <font key="font" metaFont="system"/>
@@ -284,7 +317,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <tableHeaderView key="headerView" id="ckY-Px-mJn">
-                                    <rect key="frame" x="0.0" y="0.0" width="444" height="23"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="635" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
@@ -319,7 +352,7 @@
                 </viewController>
                 <customObject id="34q-0u-YTQ" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1159" y="223.5"/>
+            <point key="canvasLocation" x="1254.5" y="223.5"/>
         </scene>
         <!--Main Prefs View Controller-->
         <scene sceneID="zAg-r8-WQ5">

--- a/MonitorControl/UI/FriendlyNameCellView.swift
+++ b/MonitorControl/UI/FriendlyNameCellView.swift
@@ -1,0 +1,25 @@
+import Cocoa
+import os.log
+
+class FriendlyNameCellView: NSTableCellView {
+  var display: Display?
+  let prefs = UserDefaults.standard
+
+  override func draw(_ dirtyRect: NSRect) {
+    super.draw(dirtyRect)
+  }
+
+  @IBAction func valueChanged(_ sender: NSTextFieldCell) {
+    let newValue = sender.stringValue
+    let originalValue = self.display?.getFriendlyName()
+
+    if newValue != originalValue {
+      print("------ Changed Value ------")
+      self.display?.setFriendlyName(newValue)
+    }
+
+    #if DEBUG
+      os_log("Value changed for friendly name: %{public}@", type: .info, sender.stringValue)
+    #endif
+  }
+}

--- a/MonitorControl/UI/FriendlyNameCellView.swift
+++ b/MonitorControl/UI/FriendlyNameCellView.swift
@@ -10,16 +10,19 @@ class FriendlyNameCellView: NSTableCellView {
   }
 
   @IBAction func valueChanged(_ sender: NSTextFieldCell) {
-    let newValue = sender.stringValue
-    let originalValue = self.display?.getFriendlyName()
+    if let display = display {
+      let newValue = sender.stringValue
+      let originalValue = display.getFriendlyName()
 
-    if newValue != originalValue {
-      print("------ Changed Value ------")
-      self.display?.setFriendlyName(newValue)
+      if newValue originalValue {
+        print("------ Changed Value ------")
+        display.setFriendlyName(newValue)
+      
+
+        #if DEBUG
+          os_log("Value changed for friendly name: %{public}@", type: .info, "from `\(originalValue)` to `\(newValue)`")
+        #endif
+      }
     }
-
-    #if DEBUG
-      os_log("Value changed for friendly name: %{public}@", type: .info, sender.stringValue)
-    #endif
   }
 }

--- a/MonitorControl/UI/FriendlyNameCellView.swift
+++ b/MonitorControl/UI/FriendlyNameCellView.swift
@@ -14,10 +14,15 @@ class FriendlyNameCellView: NSTableCellView {
       let newValue = sender.stringValue
       let originalValue = display.getFriendlyName()
 
-      if newValue originalValue {
-        print("------ Changed Value ------")
+      if newValue.isEmpty {
+        self.textField?.stringValue = originalValue
+        return
+      }
+
+      if newValue != originalValue,
+        !newValue.isEmpty {
         display.setFriendlyName(newValue)
-      
+        NotificationCenter.default.post(name: Notification.Name(Utils.PrefKeys.friendlyName.rawValue), object: nil)
 
         #if DEBUG
           os_log("Value changed for friendly name: %{public}@", type: .info, "from `\(originalValue)` to `\(newValue)`")

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -8,6 +8,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Display Name"; ObjectID = "CHc-s5-4MN"; */
 "CHc-s5-4MN.headerCell.title" = "Display Name";
 
+/* Class = "NSTableColumn"; headerCell.title = "Friendly Name"; ObjectID = "uoI-1J-RdD"; */
+"uoI-1J-RdD.headerCell.title" = "Friendly Name";
+
 /* Class = "NSTextFieldCell"; title = "Keys"; ObjectID = "Dcz-GG-1li"; */
 "Dcz-GG-1li.title" = "Keys";
 

--- a/MonitorControl/View Controllers/DisplayPrefsViewController.swift
+++ b/MonitorControl/View Controllers/DisplayPrefsViewController.swift
@@ -13,6 +13,7 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
   enum DisplayCell: String {
     case checkbox
     case name
+    case friendlyName
     case identifier
     case vendor
     case model
@@ -51,7 +52,7 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
 
       // Disable built-in displays.
       if screen.isBuiltin {
-        let display = Display(id, name: screen.displayName ?? NSLocalizedString("Unknown", comment: "unknown display name"), isEnabled: false)
+        let display = Display(id, name: screen.displayName ?? NSLocalizedString("Unknown", comment: "unknown display name"), friendlyName: nil, isEnabled: false)
         self.displays.append(display)
         continue
       }
@@ -67,9 +68,10 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
       }
 
       let name = Utils.getDisplayName(forEdid: edid)
+      let friendlyName = Utils.getFriendlyDisplayName(forDisplayId: id)
       let isEnabled = (prefs.object(forKey: "\(id)-state") as? Bool) ?? true
 
-      let display = Display(id, name: name, isEnabled: isEnabled)
+      let display = Display(id, name: name, friendlyName: friendlyName, isEnabled: isEnabled)
       self.displays.append(display)
     }
 
@@ -96,14 +98,18 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
       text = display.name
       cellType = DisplayCell.name
     } else if tableColumn == tableView.tableColumns[2] {
+      // Friendly Name
+      text = display.friendlyName
+      cellType = DisplayCell.friendlyName
+    } else if tableColumn == tableView.tableColumns[3] {
       // Identifier
       text = "\(display.identifier)"
       cellType = DisplayCell.identifier
-    } else if tableColumn == tableView.tableColumns[3] {
+    } else if tableColumn == tableView.tableColumns[4] {
       // Vendor
       text = display.identifier.vendorNumber.map { String(format: "0x%02X", $0) } ?? NSLocalizedString("unknown", comment: "unknown vendor")
       cellType = DisplayCell.vendor
-    } else if tableColumn == tableView.tableColumns[4] {
+    } else if tableColumn == tableView.tableColumns[5] {
       // Model
       text = display.identifier.modelNumber.map { String(format: "0x%02X", $0) } ?? NSLocalizedString("unknown", comment: "unknown model")
       cellType = DisplayCell.model

--- a/MonitorControl/View Controllers/DisplayPrefsViewController.swift
+++ b/MonitorControl/View Controllers/DisplayPrefsViewController.swift
@@ -52,7 +52,7 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
 
       // Disable built-in displays.
       if screen.isBuiltin {
-        let display = Display(id, name: screen.displayName ?? NSLocalizedString("Unknown", comment: "unknown display name"), friendlyName: nil, isEnabled: false)
+        let display = Display(id, name: screen.displayName ?? NSLocalizedString("Unknown", comment: "unknown display name"), isEnabled: false)
         self.displays.append(display)
         continue
       }
@@ -68,10 +68,9 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
       }
 
       let name = Utils.getDisplayName(forEdid: edid)
-      let friendlyName = Utils.getFriendlyDisplayName(forDisplayId: id)
       let isEnabled = (prefs.object(forKey: "\(id)-state") as? Bool) ?? true
 
-      let display = Display(id, name: name, friendlyName: friendlyName, isEnabled: isEnabled)
+      let display = Display(id, name: name, isEnabled: isEnabled)
       self.displays.append(display)
     }
 
@@ -99,7 +98,7 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
       cellType = DisplayCell.name
     } else if tableColumn == tableView.tableColumns[2] {
       // Friendly Name
-      text = display.friendlyName
+      text = display.getFriendlyName()
       cellType = DisplayCell.friendlyName
     } else if tableColumn == tableView.tableColumns[3] {
       // Identifier
@@ -121,6 +120,13 @@ class DisplayPrefsViewController: NSViewController, MASPreferencesViewController
         if display.name == "Mac built-in Display" {
           cell.button.isEnabled = false
         }
+        return cell
+      }
+    } else if cellType == DisplayCell.friendlyName {
+      if let cell = tableView.makeView(withIdentifier: (tableColumn?.identifier)!, owner: nil) as? FriendlyNameCellView {
+        cell.display = display
+        cell.textField?.stringValue = text
+        cell.textField?.isEditable = true
         return cell
       }
     } else {


### PR DESCRIPTION
Hi,

First PR for this from me, more than happy if you deem it unnecessary and reject it since it's all for an issue I personally have.

I've added the ability for a user to assigned "friendly names" to the monitors listed for them.

I have a problem where I have two identical monitors, that show up with the exact same name in the drop-down menu.

![Screen Shot 2019-05-13 at 18 46 21](https://user-images.githubusercontent.com/801539/57608364-2790b680-75b0-11e9-918b-487b50ee27e4.png)

My modification includes an editable cell in the preferences view where a user can specify a more meaningful name ("Left Screen" and "Right Screen" for example")

![Screen Shot 2019-05-13 at 18 48 19](https://user-images.githubusercontent.com/801539/57608527-73dbf680-75b0-11e9-9563-c53789185297.png)

These names are stored in preferences and then propagated through the UI.

![Screen Shot 2019-05-13 at 18 47 23](https://user-images.githubusercontent.com/801539/57608568-8ce4a780-75b0-11e9-8c0f-abe3ca710f11.png)

A couple of things that are probably worth noting:

1. The added logic in the DispayPrefsViewController increased the cyclomatic complexity of the tableView function to > 12 which triggers a linting warning. I didn't want to go disassembling things in there too much in case you rejected the entire pull request.
2. I haven't provided any localized strings for German/French. Happy to roll them in either part of the acceptance of this PR, or in a future PR.

It's been quite a while since I've done Prod level macOS development, so please feel free to critique anything you feel I need to address.

