### PR TITLE
Changed mute command from '0 speaker volume' to 'true' mute (0x8D)

### DIFF
--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -38,13 +38,13 @@ class Display {
 
   func mute(forceVolume: Int? = nil) {
     var value = 0
-    
-    if self.isMuted && (forceVolume == nil || forceVolume! > 0) {
+
+    if self.isMuted, forceVolume == nil || forceVolume! > 0 {
       value = forceVolume ?? self.getValue(for: .audioSpeakerVolume)
       self.saveValue(value, for: .audioSpeakerVolume)
-      
+
       self.isMuted = false
-    } else if !self.isMuted && (forceVolume == nil || forceVolume == 0) {
+    } else if !self.isMuted, forceVolume == nil || forceVolume == 0 {
       self.isMuted = true
     }
 
@@ -60,7 +60,7 @@ class Display {
         self.showOsd(command: .audioSpeakerVolume, value: value)
         self.playVolumeChangedSound()
       }
-      
+
       self.saveValue(muteValue, for: .audioMuteScreenBlank)
     }
 
@@ -70,7 +70,7 @@ class Display {
   }
 
   func setVolume(to value: Int) {
-    if value > 0 && self.isMuted {
+    if value > 0, self.isMuted {
       self.mute(forceVolume: value)
     } else if value == 0 {
       self.mute(forceVolume: 0)

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.2</string>
 	<key>CFBundleVersion</key>
-	<string>515</string>
+	<string>516</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.2</string>
 	<key>CFBundleVersion</key>
-	<string>515</string>
+	<string>516</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
On my particular monitor (Samsung C34J79X), when the speaker volume is set to "0" and the MonitorControl OSD shows the audio as muted, the sound is not actually muted, it's just really soft.

Checking out the available DDC commands, there was one (0x8D - .audioMuteScreenBlank) that seemed to actually do the trick nicely.

I've implemented this such that the transitions between volume > 0, mute and unmute should be covered - from my testing on two monitors (mine and an LG 27UD58-B), they seem to work correctly.

I'm not 100% sure whether all monitors are able to handle the 0x8D command, so it'd be great if there could be some more testing on this.

Also, I'm not well-versed in Swift, so any suggestions to improve the quality of the change would be most welcome!

Lastly, this is an amazing and completely necessary piece of software, so thanks to all the contributors and maintainers!