### PR TITLE
Fix mute on monitors that don’t support it (#107)

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -18,8 +18,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   var monitorItems: [NSMenuItem] = []
 
-  let step = 100 / 16
-
   var displayManager: DisplayManager?
   var mediaKeyTap: MediaKeyTap?
   var prefsController: NSWindowController?
@@ -214,20 +212,14 @@ extension AppDelegate: MediaKeyTapDelegate {
     for display in allDisplays {
       if (prefs.object(forKey: "\(display.identifier)-state") as? Bool) ?? true {
         switch mediaKey {
-        case .brightnessUp:
-          let value = display.calcNewValue(for: .brightness, withRel: +(isSmallIncrement ? self.step / 4 : self.step))
-          display.setBrightness(to: value, isSmallIncrement: isSmallIncrement)
-        case .brightnessDown:
-          let value = currentDisplay.calcNewValue(for: .brightness, withRel: -(isSmallIncrement ? self.step / 4 : self.step))
-          display.setBrightness(to: value, isSmallIncrement: isSmallIncrement)
+        case .brightnessUp, .brightnessDown:
+          let osdValue = display.calcNewValue(for: .brightness, isUp: mediaKey == .brightnessUp, isSmallIncrement: isSmallIncrement)
+          display.setBrightness(to: osdValue)
         case .mute:
-          display.mute()
-        case .volumeUp:
-          let value = display.calcNewValue(for: .audioSpeakerVolume, withRel: +(isSmallIncrement ? self.step / 4 : self.step))
-          display.setVolume(to: value, isSmallIncrement: isSmallIncrement)
-        case .volumeDown:
-          let value = display.calcNewValue(for: .audioSpeakerVolume, withRel: -(isSmallIncrement ? self.step / 4 : self.step))
-          display.setVolume(to: value, isSmallIncrement: isSmallIncrement)
+          display.toggleMute()
+        case .volumeUp, .volumeDown:
+          let osdValue = display.calcNewValue(for: .audioSpeakerVolume, isUp: mediaKey == .volumeUp, isSmallIncrement: isSmallIncrement)
+          display.setVolume(to: osdValue)
         default:
           return
         }

--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -8,7 +8,6 @@ class Display {
   let name: String
   let isBuiltin: Bool
   var isEnabled: Bool
-  var isMuted: Bool = false
   var brightnessSliderHandler: SliderHandler?
   var volumeSliderHandler: SliderHandler?
   var contrastSliderHandler: SliderHandler?
@@ -37,13 +36,14 @@ class Display {
   private let prefs = UserDefaults.standard
   private var audioPlayer: AVAudioPlayer?
 
+  private let osdChicletBoxes: Float = 16
+
   init(_ identifier: CGDirectDisplayID, name: String, isBuiltin: Bool, isEnabled: Bool = true) {
     self.identifier = identifier
     self.name = name
     self.isEnabled = isBuiltin ? false : isEnabled
     self.ddc = DDC(for: identifier)
     self.isBuiltin = isBuiltin
-    self.isMuted = self.getValue(for: .audioMuteScreenBlank) == 1
   }
 
   // On some displays, the display's OSD overlaps the macOS OSD,
@@ -58,77 +58,115 @@ class Display {
     }
   }
 
-  func mute(forceVolume: Int? = nil) {
-    var value = 0
+  func isMuted() -> Bool {
+    return self.getValue(for: .audioMuteScreenBlank) == 1
+  }
 
-    if self.isMuted, forceVolume == nil || forceVolume! > 0 {
-      value = forceVolume ?? self.getValue(for: .audioSpeakerVolume)
-      self.saveValue(value, for: .audioSpeakerVolume)
+  func toggleMute(fromVolumeSlider: Bool = false) {
+    var muteValue: Int
+    var volumeOSDValue: Int
 
-      self.isMuted = false
-    } else if !self.isMuted, forceVolume == nil || forceVolume == 0 {
-      self.isMuted = true
+    if !self.isMuted() {
+      muteValue = 1
+      volumeOSDValue = 0
+    } else {
+      muteValue = 2
+      volumeOSDValue = self.getValue(for: .audioSpeakerVolume)
+
+      // The volume that will be set immediately after setting unmute while the old set volume was 0 is unpredictable
+      // Hence, just set it to a single filled chiclet
+      if volumeOSDValue == 0 {
+        volumeOSDValue = self.stepSize(for: .audioSpeakerVolume, isSmallIncrement: false)
+        self.saveValue(volumeOSDValue, for: .audioSpeakerVolume)
+      }
     }
 
     DispatchQueue.global(qos: .userInitiated).async {
-      let muteValue = self.isMuted ? 1 : 2
-      guard self.ddc?.write(command: .audioMuteScreenBlank, value: UInt16(muteValue), errorRecoveryWaitTime: self.hideOsd ? 0 : nil) == true else {
-        self.setVolume(to: value)
+      let volumeDDCValue = UInt16(volumeOSDValue)
+
+      guard self.ddc?.write(command: .audioSpeakerVolume, value: volumeDDCValue) == true else {
         return
       }
 
-      if forceVolume == nil || forceVolume == 0 {
-        self.hideDisplayOsd()
-        self.showOsd(command: .audioSpeakerVolume, value: value)
-        self.playVolumeChangedSound()
+      if self.supportsMuteCommand() {
+        guard self.ddc?.write(command: .audioMuteScreenBlank, value: UInt16(muteValue)) == true else {
+          return
+        }
       }
 
       self.saveValue(muteValue, for: .audioMuteScreenBlank)
-    }
 
-    if let slider = volumeSliderHandler?.slider {
-      DispatchQueue.main.async {
-        slider.intValue = Int32(value)
+      if !fromVolumeSlider {
+        self.hideDisplayOsd()
+        self.showOsd(command: .audioSpeakerVolume, value: volumeOSDValue)
+
+        if volumeOSDValue > 0 {
+          self.playVolumeChangedSound()
+        }
+
+        if let slider = self.volumeSliderHandler?.slider {
+          DispatchQueue.main.async {
+            slider.intValue = Int32(volumeDDCValue)
+          }
+        }
       }
     }
   }
 
-  func setVolume(to value: Int, isSmallIncrement: Bool = false) {
-    if value > 0, self.isMuted {
-      self.mute(forceVolume: value)
-    } else if value == 0 {
-      self.mute(forceVolume: 0)
-      return
+  func setVolume(to volumeOSDValue: Int) {
+    var muteValue: Int?
+    let volumeDDCValue = UInt16(volumeOSDValue)
+
+    if self.isMuted(), volumeOSDValue > 0 {
+      muteValue = 2
+    } else if !self.isMuted(), volumeOSDValue == 0 {
+      muteValue = 1
     }
 
     DispatchQueue.global(qos: .userInitiated).async {
-      guard self.ddc?.write(command: .audioSpeakerVolume, value: UInt16(value), errorRecoveryWaitTime: self.hideOsd ? 0 : nil) == true else {
+      guard self.ddc?.write(command: .audioSpeakerVolume, value: volumeDDCValue) == true else {
         return
       }
 
-      self.hideDisplayOsd()
-      self.showOsd(command: .audioSpeakerVolume, value: value, isSmallIncrement: isSmallIncrement)
-      self.playVolumeChangedSound()
-    }
+      if muteValue != nil {
+        // If the mute command is supported, set its value accordingly
+        if self.supportsMuteCommand() {
+          guard self.ddc?.write(command: .audioMuteScreenBlank, value: UInt16(muteValue!)) == true else {
+            return
+          }
+        }
 
-    if let slider = volumeSliderHandler?.slider {
-      DispatchQueue.main.async {
-        slider.intValue = Int32(value)
+        self.saveValue(muteValue!, for: .audioMuteScreenBlank)
+      }
+
+      self.saveValue(volumeOSDValue, for: .audioSpeakerVolume)
+
+      self.hideDisplayOsd()
+      self.showOsd(command: .audioSpeakerVolume, value: volumeOSDValue)
+
+      if volumeOSDValue > 0 {
+        self.playVolumeChangedSound()
+      }
+
+      if let slider = self.volumeSliderHandler?.slider {
+        DispatchQueue.main.async {
+          slider.intValue = Int32(volumeDDCValue)
+        }
       }
     }
-
-    self.saveValue(value, for: .audioSpeakerVolume)
   }
 
-  func setBrightness(to value: Int, isSmallIncrement: Bool = false) {
+  func setBrightness(to osdValue: Int) {
+    let ddcValue = UInt16(osdValue)
+
     if self.prefs.bool(forKey: Utils.PrefKeys.lowerContrast.rawValue) {
-      if value == 0 {
+      if ddcValue == 0 {
         DispatchQueue.global(qos: .userInitiated).async {
-          _ = self.ddc?.write(command: .contrast, value: UInt16(value))
+          _ = self.ddc?.write(command: .contrast, value: ddcValue)
         }
 
         if let slider = contrastSliderHandler?.slider {
-          slider.intValue = Int32(value)
+          slider.intValue = Int32(ddcValue)
         }
       } else if self.getValue(for: DDC.Command.brightness) == 0 {
         let contrastValue = self.getValue(for: DDC.Command.contrast)
@@ -140,23 +178,67 @@ class Display {
     }
 
     DispatchQueue.global(qos: .userInitiated).async {
-      guard self.ddc?.write(command: .brightness, value: UInt16(value)) == true else {
+      guard self.ddc?.write(command: .brightness, value: ddcValue) == true else {
         return
       }
 
-      self.showOsd(command: .brightness, value: value, isSmallIncrement: isSmallIncrement)
+      self.showOsd(command: .brightness, value: osdValue)
     }
 
     if let slider = brightnessSliderHandler?.slider {
-      slider.intValue = Int32(value)
+      slider.intValue = Int32(ddcValue)
     }
 
-    self.saveValue(value, for: .brightness)
+    self.saveValue(osdValue, for: .brightness)
   }
 
-  func calcNewValue(for command: DDC.Command, withRel rel: Int) -> Int {
+  func readDDCValues(for command: DDC.Command, tries: UInt, minReplyDelay delay: UInt64?) -> (current: UInt16, max: UInt16)? {
+    var values: (UInt16, UInt16)?
+
+    if self.ddc?.supported(minReplyDelay: delay) == true {
+      os_log("Display supports DDC.", type: .debug)
+    } else {
+      os_log("Display does not support DDC.", type: .debug)
+    }
+
+    if self.ddc?.enableAppReport() == true {
+      os_log("Display supports enabling DDC application report.", type: .debug)
+    } else {
+      os_log("Display does not support enabling DDC application report.", type: .debug)
+    }
+
+    values = self.ddc?.read(command: command, tries: tries, minReplyDelay: delay)
+
+    if values != nil {
+      return values!
+    }
+
+    return nil
+  }
+
+  func calcNewValue(for command: DDC.Command, isUp: Bool, isSmallIncrement: Bool) -> Int {
     let currentValue = self.getValue(for: command)
-    return max(0, min(self.getMaxValue(for: command), currentValue + rel))
+    let nextValue: Int
+
+    if isSmallIncrement {
+      nextValue = currentValue + (isUp ? 1 : -1)
+    } else {
+      let filledChicletBoxes = self.osdChicletBoxes * (Float(currentValue) / Float(self.getMaxValue(for: command)))
+
+      var nextFilledChicletBoxes: Float
+      var fillecChicletBoxesRel: Float = isUp ? 1 : -1
+
+      // This is a workaround to ensure that if the user has set the value using a small step (that is, the current chiclet box isn't completely filled,
+      // the next regular up or down step will only fill or empty that chiclet, and not the next one as well - it only really works because the max value is 100
+      if (isUp && ceil(filledChicletBoxes) - filledChicletBoxes > 0.15) || (!isUp && filledChicletBoxes - floor(filledChicletBoxes) > 0.15) {
+        fillecChicletBoxesRel = 0
+      }
+
+      nextFilledChicletBoxes = isUp ? ceil(filledChicletBoxes + fillecChicletBoxesRel) : floor(filledChicletBoxes + fillecChicletBoxesRel)
+      nextValue = Int(Float(self.getMaxValue(for: command)) * (nextFilledChicletBoxes / self.osdChicletBoxes))
+    }
+
+    return max(0, min(self.getMaxValue(for: command), Int(nextValue)))
   }
 
   func getValue(for command: DDC.Command) -> Int {
@@ -225,30 +307,35 @@ class Display {
     self.prefs.set(value, forKey: "pollingCount-\(self.identifier)")
   }
 
-  private func showOsd(command: DDC.Command, value: Int, isSmallIncrement: Bool = false) {
+  private func stepSize(for command: DDC.Command, isSmallIncrement: Bool) -> Int {
+    return isSmallIncrement ? 1 : Int(floor(Float(self.getMaxValue(for: command)) / self.osdChicletBoxes))
+  }
+
+  private func showOsd(command: DDC.Command, value: Int) {
     guard let manager = OSDManager.sharedManager() as? OSDManager else {
       return
     }
 
-    let maxValue = self.getMaxValue(for: command)
-
     var osdImage: Int64 = 1 // Brightness Image
     if command == .audioSpeakerVolume {
       osdImage = 3 // Speaker image
-      if self.isMuted {
+      if self.isMuted() {
         osdImage = 4 // Mute speaker
       }
     }
-
-    let step = isSmallIncrement ? maxValue / maxValue : maxValue / 16
 
     manager.showImage(osdImage,
                       onDisplayID: self.identifier,
                       priority: 0x1F4,
                       msecUntilFade: 1000,
-                      filledChiclets: UInt32(value / step),
-                      totalChiclets: UInt32(maxValue / step),
+                      filledChiclets: UInt32(value),
+                      totalChiclets: UInt32(self.getMaxValue(for: command)),
                       locked: false)
+  }
+
+  private func supportsMuteCommand() -> Bool {
+    // Monitors which don't support the mute command - e.g. Dell U3419W - will have a maximum value of 100 for the DDC mute command
+    return self.getMaxValue(for: .audioMuteScreenBlank) == 2
   }
 
   private func playVolumeChangedSound() {

--- a/MonitorControl/Support/Utils.swift
+++ b/MonitorControl/Support/Utils.swift
@@ -42,40 +42,58 @@ class Utils: NSObject {
       }
 
       var values: (UInt16, UInt16)?
-
       let delay = display.needsLongerDelay ? UInt64(40 * kMillisecondScale) : nil
-
-      if display.ddc?.supported(minReplyDelay: delay) == true {
-        os_log("Display supports DDC.", type: .debug)
-      } else {
-        os_log("Display does not support DDC.", type: .debug)
-      }
-
-      if display.ddc?.enableAppReport() == true {
-        os_log("Display supports enabling DDC application report.", type: .debug)
-      } else {
-        os_log("Display does not support enabling DDC application report.", type: .debug)
-      }
 
       let tries = UInt(display.getPollingCount())
       os_log("Polling %{public}@ times", type: .info, String(tries))
 
       if tries != 0 {
-        values = display.ddc?.read(command: command, tries: tries, minReplyDelay: delay)
+        values = display.readDDCValues(for: command, tries: tries, minReplyDelay: delay)
       }
 
-      let (currentValue, maxValue) = values ?? (UInt16(display.getValue(for: command)), UInt16(display.getMaxValue(for: command)))
+      let (currentDDCValue, maxValue) = values ?? (UInt16(display.getValue(for: command)), UInt16(display.getMaxValue(for: command)))
 
-      display.saveValue(Int(currentValue), for: command)
+      display.saveValue(Int(currentDDCValue), for: command)
       display.saveMaxValue(Int(maxValue), for: command)
 
       os_log("%{public}@ (%{public}@):", type: .info, display.name, String(reflecting: command))
-      os_log(" - current value: %{public}@", type: .info, String(currentValue))
-      os_log(" - maximum value: %{public}@", type: .info, String(maxValue))
+      os_log(" - current ddc value: %{public}@", type: .info, String(currentDDCValue))
+      os_log(" - maximum ddc value: %{public}@", type: .info, String(maxValue))
 
-      DispatchQueue.main.async {
-        slider.integerValue = Int(currentValue)
-        slider.maxValue = Double(maxValue)
+      if command != .audioSpeakerVolume {
+        DispatchQueue.main.async {
+          slider.integerValue = Int(currentDDCValue)
+          slider.maxValue = Double(maxValue)
+        }
+      } else {
+        // If we're looking at the audio speaker volume, also retrieve the values for the mute command
+        var muteValues: (current: UInt16, max: UInt16)?
+        os_log("Polling %{public}@ times", type: .info, String(tries))
+
+        if tries != 0 {
+          muteValues = display.readDDCValues(for: .audioMuteScreenBlank, tries: tries, minReplyDelay: delay)
+        }
+
+        os_log("%{public}@ (%{public}@):", type: .info, display.name, String(reflecting: DDC.Command.audioMuteScreenBlank))
+
+        if muteValues != nil {
+          os_log(" - current ddc value: %{public}@", type: .info, String(muteValues!.current))
+          os_log(" - maximum ddc value: %{public}@", type: .info, String(muteValues!.max))
+
+          display.saveValue(Int(muteValues!.current), for: command)
+          display.saveMaxValue(Int(muteValues!.max), for: command)
+        }
+
+        // If the system is not currently muted, or doesn't support the mute command, display the current volume as the slider value
+        DispatchQueue.main.async {
+          if muteValues == nil || muteValues!.current == 2 {
+            slider.integerValue = Int(currentDDCValue)
+          } else {
+            slider.integerValue = 0
+          }
+
+          slider.maxValue = Double(maxValue)
+        }
       }
     }
     return handler

--- a/MonitorControl/UI/SliderHandler.swift
+++ b/MonitorControl/UI/SliderHandler.swift
@@ -23,6 +23,11 @@ class SliderHandler {
       slider.integerValue = value
     }
 
+    // For the speaker volume slider, also set/unset the mute command when the value is changed from/to 0
+    if self.cmd == .audioSpeakerVolume, (self.display.isMuted() && value > 0) || (!self.display.isMuted() && value == 0) {
+      self.display.toggleMute(fromVolumeSlider: true)
+    }
+
     _ = self.display.ddc?.write(command: self.cmd, value: UInt16(value))
     self.display.saveValue(value, for: self.cmd)
   }


### PR DESCRIPTION
- FIXED: Issue where trying to use the “true” mute command on unsupported monitors would cause the mute/unmute key to do nothing
- FIXED: Issue where “0” chiclets would be shown when the step value was less than the value of one filled chiclet but greater than 0