### PR TITLE
Fix Issue detecting the output device

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     self.displayManager = DisplayManager()
     self.setupViewControllers()
     self.subscribeEventListeners()
-    self.startOrRestartMediaKeyTap()
+    self.updateMediaKeyTap()
     self.statusItem.image = NSImage(named: "status")
     self.statusItem.menu = self.statusMenu
     self.setDefaultPrefs()
@@ -175,7 +175,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // listen for accessibility status changes
     _ = DistributedNotificationCenter.default().addObserver(forName: .accessibilityApi, object: nil, queue: nil) { _ in
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-        self.startOrRestartMediaKeyTap()
+        self.updateMediaKeyTap()
       }
     }
   }
@@ -259,7 +259,7 @@ extension AppDelegate: MediaKeyTapDelegate {
   // MARK: - Prefs notification
 
   @objc func handleListenForChanged() {
-    self.startOrRestartMediaKeyTap()
+    self.updateMediaKeyTap()
   }
 
   @objc func handleShowContrastChanged() {
@@ -273,10 +273,10 @@ extension AppDelegate: MediaKeyTapDelegate {
   @objc func handlePreferenceReset() {
     self.setDefaultPrefs()
     self.updateDisplays()
-    self.startOrRestartMediaKeyTap()
+    self.updateMediaKeyTap()
   }
 
-  private func startOrRestartMediaKeyTap() {
+  private func updateMediaKeyTap() {
     var keys: [MediaKey]
 
     switch prefs.integer(forKey: Utils.PrefKeys.listenFor.rawValue) {
@@ -294,8 +294,11 @@ extension AppDelegate: MediaKeyTapDelegate {
       keys.removeAll { keysToDelete.contains($0) }
     }
     self.mediaKeyTap?.stop()
-    self.mediaKeyTap = MediaKeyTap(delegate: self, for: keys, observeBuiltIn: false)
-    self.mediaKeyTap?.start()
+    // returning an empty array listens for all mediakeys in MediaKeyTap
+    if keys.count > 0 {
+      self.mediaKeyTap = MediaKeyTap(delegate: self, for: keys, observeBuiltIn: false)
+      self.mediaKeyTap?.start()
+    }
   }
 }
 
@@ -307,7 +310,7 @@ extension AppDelegate: EventSubscriber {
         os_log("Default output device changed to “%{public}@”.", type: .info, audioDevice.name)
         os_log("Can device set its own volume? %{public}@", type: .info, audioDevice.canSetVirtualMasterVolume(direction: .playback).description)
       #endif
-      self.startOrRestartMediaKeyTap()
+      self.updateMediaKeyTap()
     }
   }
 }

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>638</string>
+	<string>640</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>638</string>
+	<string>640</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
fixes #172 

Apparently returning an empty array to `MediaKeyTap` makes it listen to all keys. Something that might need to be fixed in MediaKeyTap? @the0neyouseek 