### PR TITLE
Feature/macos26 brightness hud

### DIFF
--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		F06792F6200A745F0066C438 /* MonitorControlHelper.app in [Login] Copy Helper to start at Login */ = {isa = PBXBuildFile; fileRef = F06792E7200A73460066C438 /* MonitorControlHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F0A489C4279C71B200BEDFD6 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A489C3279C71B200BEDFD6 /* OnboardingViewController.swift */; };
 		FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E0895249D584C003A50BB /* OSDUtils.swift */; };
+		AA10B0002D00000100000001 /* BrightnessHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10B0012D00000100000001 /* BrightnessHUDController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -181,6 +182,7 @@
 		FB5DB28F2AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InternetAccessPolicy.strings"; sourceTree = "<group>"; };
 		FB5DB2902AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FE4E0895249D584C003A50BB /* OSDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDUtils.swift; sourceTree = "<group>"; };
+		AA10B0012D00000100000001 /* BrightnessHUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessHUDController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -317,6 +319,7 @@
 				AA16139A26BE772E00DCF027 /* Arm64DDC.swift */,
 				AA4398A826DD55DA00943F16 /* IntelDDC.swift */,
 				FE4E0895249D584C003A50BB /* OSDUtils.swift */,
+				AA10B0012D00000100000001 /* BrightnessHUDController.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				AA062E8E26CA7BE5007E628C /* DisplaysPrefsCellView.swift in Sources */,
 				AA25F6D726E68C160087F3A2 /* MediaKeyTapManager.swift in Sources */,
 				FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */,
+				AA10B0002D00000100000001 /* BrightnessHUDController.swift in Sources */,
 				6CBFE27A23DB266000D1BC41 /* Display.swift in Sources */,
 				AA44E70727038F7F00E06865 /* KeyboardShortcutsManager.swift in Sources */,
 				F03A8DF21FFBAA6F0034DC27 /* OtherDisplay.swift in Sources */,

--- a/MonitorControl/Support/BrightnessHUDController.swift
+++ b/MonitorControl/Support/BrightnessHUDController.swift
@@ -1,0 +1,120 @@
+//  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+
+import Cocoa
+
+class BrightnessHUDController {
+  static let shared = BrightnessHUDController()
+
+  private var windows: [CGDirectDisplayID: NSWindow] = [:]
+  private var fadeTimers: [CGDirectDisplayID: Timer] = [:]
+
+  func show(displayID: CGDirectDisplayID, value: Float, maxValue: Float) {
+    DispatchQueue.main.async {
+      self.showHUD(displayID: displayID, value: value, maxValue: maxValue)
+    }
+  }
+
+  private func showHUD(displayID: CGDirectDisplayID, value: Float, maxValue: Float) {
+    let percentage = maxValue > 0 ? min(max(value / maxValue, 0), 1) : 0
+    let window: NSWindow
+    let hudView: BrightnessHUDView
+
+    if let existing = windows[displayID], let existingView = existing.contentView as? BrightnessHUDView {
+      window = existing
+      hudView = existingView
+      hudView.update(percentage: percentage)
+    } else {
+      hudView = BrightnessHUDView(percentage: percentage)
+      window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 200, height: 56), styleMask: [.borderless], backing: .buffered, defer: false)
+      window.contentView = hudView
+      window.backgroundColor = .clear
+      window.isOpaque = false
+      window.level = .floating
+      window.ignoresMouseEvents = true
+      window.collectionBehavior = [.stationary, .canJoinAllSpaces, .ignoresCycle]
+      window.hasShadow = true
+      windows[displayID] = window
+    }
+
+    if let screen = NSScreen.screens.first(where: { $0.displayID == displayID }) {
+      let screenFrame = screen.frame
+      let windowFrame = window.frame
+      let x = screenFrame.midX - windowFrame.width / 2
+      let y = screenFrame.origin.y + screenFrame.height * 0.12
+      window.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    window.alphaValue = 1.0
+    window.orderFrontRegardless()
+
+    fadeTimers[displayID]?.invalidate()
+    fadeTimers[displayID] = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+      NSAnimationContext.runAnimationGroup({ context in
+        context.duration = 0.3
+        window.animator().alphaValue = 0
+      }, completionHandler: {
+        window.orderOut(nil)
+        self?.windows.removeValue(forKey: displayID)
+        self?.fadeTimers.removeValue(forKey: displayID)
+      })
+    }
+  }
+}
+
+// MARK: - HUD View
+
+private class BrightnessHUDView: NSVisualEffectView {
+  private let progressBar = NSView()
+  private let progressTrack = NSView()
+  private let iconView = NSImageView()
+  private let percentLabel = NSTextField(labelWithString: "")
+  private var percentage: Float = 0
+
+  convenience init(percentage: Float) {
+    self.init(frame: NSRect(x: 0, y: 0, width: 200, height: 56))
+    self.percentage = percentage
+    setup()
+  }
+
+  private func setup() {
+    material = .hudWindow
+    blendingMode = .behindWindow
+    state = .active
+    wantsLayer = true
+    layer?.cornerRadius = 14
+
+    if #available(macOS 11.0, *) {
+      iconView.image = NSImage(systemSymbolName: "sun.max.fill", accessibilityDescription: "Brightness")
+      iconView.contentTintColor = .labelColor
+    } else {
+      iconView.image = NSImage(named: "NSBrightnessTemplate")
+    }
+    iconView.frame = NSRect(x: 12, y: 16, width: 24, height: 24)
+    addSubview(iconView)
+
+    progressTrack.frame = NSRect(x: 44, y: 24, width: 108, height: 8)
+    progressTrack.wantsLayer = true
+    progressTrack.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.2).cgColor
+    progressTrack.layer?.cornerRadius = 4
+    addSubview(progressTrack)
+
+    progressBar.frame = NSRect(x: 0, y: 0, width: CGFloat(percentage) * 108, height: 8)
+    progressBar.wantsLayer = true
+    progressBar.layer?.backgroundColor = NSColor.white.cgColor
+    progressBar.layer?.cornerRadius = 4
+    progressTrack.addSubview(progressBar)
+
+    percentLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+    percentLabel.textColor = .secondaryLabelColor
+    percentLabel.stringValue = "\(Int(round(percentage * 100)))%"
+    percentLabel.sizeToFit()
+    percentLabel.frame.origin = NSPoint(x: 160, y: 20)
+    addSubview(percentLabel)
+  }
+
+  func update(percentage: Float) {
+    self.percentage = percentage
+    progressBar.frame.size.width = CGFloat(percentage) * 108
+    percentLabel.stringValue = "\(Int(round(percentage * 100)))%"
+  }
+}

--- a/MonitorControl/Support/BrightnessHUDController.swift
+++ b/MonitorControl/Support/BrightnessHUDController.swift
@@ -54,6 +54,7 @@ class BrightnessHUDController {
         window.animator().alphaValue = 0
       }, completionHandler: {
         window.orderOut(nil)
+        guard self?.windows[displayID] === window else { return }
         self?.windows.removeValue(forKey: displayID)
         self?.fadeTimers.removeValue(forKey: displayID)
       })
@@ -116,5 +117,6 @@ private class BrightnessHUDView: NSVisualEffectView {
     self.percentage = percentage
     progressBar.frame.size.width = CGFloat(percentage) * 108
     percentLabel.stringValue = "\(Int(round(percentage * 100)))%"
+    percentLabel.sizeToFit()
   }
 }

--- a/MonitorControl/Support/OSDUtils.swift
+++ b/MonitorControl/Support/OSDUtils.swift
@@ -22,6 +22,10 @@ class OSDUtils: NSObject {
   }
 
   static func showOsd(displayID: CGDirectDisplayID, command: Command, value: Float, maxValue: Float = 1, roundChiclet: Bool = false, lock: Bool = false) {
+    if command == .brightness, ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 {
+      BrightnessHUDController.shared.show(displayID: displayID, value: value, maxValue: maxValue)
+      return
+    }
     guard let manager = OSDManager.sharedManager() as? OSDManager else {
       return
     }


### PR DESCRIPTION
This pull request introduces a new custom brightness HUD overlay for macOS 15 (Sonoma) and above, replacing the system OSD for brightness changes on supported systems. The main change is the addition of the `BrightnessHUDController`, which displays a modern, animated heads-up display when brightness is adjusted. The implementation is modular and only activates on macOS 15 or newer, maintaining the existing behavior on older versions.

Key changes:

**Feature Addition: Custom Brightness HUD**
* Added new file `BrightnessHUDController.swift` implementing a custom heads-up display for brightness changes, including a controller and a visual effect view for the overlay. The HUD shows the current brightness as a percentage with a progress bar and icon, animates its appearance and disappearance, and is managed per display.
* Registered `BrightnessHUDController.swift` in the Xcode project file, adding it to the project group and build sources. [[1]](diffhunk://#diff-789ccc1b84e12850b9ead0253211893b9eec9a9723a99431079a2c69ec5c7a55R185) [[2]](diffhunk://#diff-789ccc1b84e12850b9ead0253211893b9eec9a9723a99431079a2c69ec5c7a55R322) [[3]](diffhunk://#diff-789ccc1b84e12850b9ead0253211893b9eec9a9723a99431079a2c69ec5c7a55R61) [[4]](diffhunk://#diff-789ccc1b84e12850b9ead0253211893b9eec9a9723a99431079a2c69ec5c7a55R635)

**Integration with Existing OSD Logic**
* Updated `OSDUtils.swift` to use the new `BrightnessHUDController` for brightness commands on macOS 15 and above, falling back to the legacy OSD otherwise.